### PR TITLE
fix: replace @hookform resolver with local zod resolver

### DIFF
--- a/src/pages/auth/LoginPage.jsx
+++ b/src/pages/auth/LoginPage.jsx
@@ -1,6 +1,6 @@
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { zodResolver } from "@hookform/resolvers/zod";
+import { zodResolver } from "../../utils/zodResolver";
 import { useNavigate } from "react-router-dom";
 
 // Schema validasi

--- a/src/utils/zodResolver.js
+++ b/src/utils/zodResolver.js
@@ -1,0 +1,23 @@
+export const zodResolver = (schema) => async (data) => {
+  const result = schema.safeParse(data);
+  if (result.success) {
+    return {
+      values: result.data,
+      errors: {},
+    };
+  }
+
+  const fieldErrors = result.error.flatten().fieldErrors;
+  const errors = Object.keys(fieldErrors).reduce((acc, key) => {
+    const messages = fieldErrors[key];
+    if (messages && messages.length) {
+      acc[key] = { type: "validation", message: messages[0] };
+    }
+    return acc;
+  }, {});
+
+  return {
+    values: {},
+    errors,
+  };
+};


### PR DESCRIPTION
## Summary
- use custom zod resolver instead of missing @hookform package
- add simple utility to translate Zod errors for react-hook-form

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build` (fails: "default" is not exported by src/pages/admin/DashboardAdmin.jsx)


------
https://chatgpt.com/codex/tasks/task_e_689ee962bdb88331a6b02430fe3d4540